### PR TITLE
Enable better Dev Tools compatibility

### DIFF
--- a/src/Aux.js
+++ b/src/Aux.js
@@ -1,3 +1,4 @@
-module.exports = (props) => {
+const Aux = (props) => {
   return props.children;
 };
+export default Aux


### PR DESCRIPTION
Before the change, the dev tools would show the component as Unknown:
![image](https://user-images.githubusercontent.com/26197727/29739923-1157e48c-8a53-11e7-96e4-05e0dc959355.png)
That is because of the anonymous function. Adding a name to the function allows the dev tools to show as follow:
![image](https://user-images.githubusercontent.com/26197727/29739928-31c1b068-8a53-11e7-8804-102a25f2a82d.png)
