### PR TITLE
Support non-transpiled code

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const Root = () => {
 
 ```
 
-However, it requires manually ensuring key uniqueness and I am to [lazy](http://threevirtues.com/) for this.
+However, it requires manually ensuring key uniqueness and I am too [lazy](http://threevirtues.com/) for this.
 
 ### Whats with the name?
 

--- a/src/Aux.js
+++ b/src/Aux.js
@@ -1,3 +1,3 @@
-module.exports = (props) => {
+module.exports = function Aux (props) {
   return props.children;
 };


### PR DESCRIPTION
I think it is safe to assume many people are using Babel to support older browser, while still writing ES2015+ syntax.

I also think it is considered good practice to not run Babel over all of your `node_modules`. Because of this, the arrow function used will not work in older browsers unless it is explicitly targeted by Babel. This seems silly since this package is so small.

I have made the following change in order to support older browsers with no extra work:

```js
module.exports = function (props) {
  return props.children;
};
```

This change can also make the PR raised by @Ron-Burg, #2, a little cleaner, in my opinion, by simply adding `Aux` to the function name, which could not be done with an arrow function:

```js
module.exports = function Aux (props) {
  return props.children;
};
```

I also fixed a _small_ typo in the README.

This project is cool. Thanks for taking the time to publish it, even if it is just 3 lines. 😉 