### PR TITLE
Change `React.Component` to `React.ReactNode`.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'react-aux' {
     import * as React from 'react';
     type AuxProps = {
-        children: Array<React.Component>
+        children: Array<React.ReactNode>
     }
     class Aux extends React.Component<AuxProps, any> {}
     export default Aux;


### PR DESCRIPTION
Otherwise you get the error:
```
TS2322: Type '{ children: Element[]; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Aux> & Readonly<{ children?: ReactNode; }> & Reado...'.
  Type '{ children: Element[]; }' is not assignable to type 'Readonly<AuxProps>'.
    Types of property 'children' are incompatible.
      Type 'Element[]' is not assignable to type 'Component<{}, {}>[]'.
        Type 'Element' is not assignable to type 'Component<{}, {}>'.
          Property 'setState' is missing in type 'Element'.
```